### PR TITLE
Update neos/neos version requirement to support 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Preliminary solution for speeding up the workspace module performance .",
     "require": {
-        "neos/neos": "^7.3"
+        "neos/neos": "^7.3 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows the package to also be used in Neos 8.x setups without any change. As no code changes were neccessary, I added Neos ^8.0 as allowed version.